### PR TITLE
[Draft] Proof of concept: Arduino framework support

### DIFF
--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -261,18 +261,7 @@ async def to_code(config):
         )
 
     cg.add_define("USE_VOICE_ASSISTANT")
-    esp32.add_idf_component(
-        name="esp-tflite-micro",
-        repo="https://github.com/espressif/esp-tflite-micro",
-        # path="components",
-        # components=["esp-radar"],
-    )
-    # esp32.add_idf_component(
-    #     name="esp-nn",
-    #     repo="https://github.com/espressif/esp-nn",
-    #     # path="components",
-    #     # components=["esp-radar"],
-    # )
+    cg.add_library("https://github.com/h3ndrik/tflite-micro-arduino-library.git")
 
     cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")
     cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -261,7 +261,11 @@ async def to_code(config):
         )
 
     cg.add_define("USE_VOICE_ASSISTANT")
-    cg.add_library("https://github.com/h3ndrik/tflite-micro-arduino-library.git")
+    cg.add_library(
+            name = "TFLite-Micro",
+            repository="https://github.com/h3ndrik/tflite-micro-arduino-library.git",
+            version="dd363b81abcc45d1d2447063972165ccc3dcc258"
+        )
 
     cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")
     cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -277,6 +277,7 @@ async def to_code(config):
     cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")
     cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")
     cg.add_build_flag("-DESP_NN")
+    cg.add_build_flag("-DCONFIG_IDF_TARGET_ESP32")
 
 
 VOICE_ASSISTANT_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(VoiceAssistant)})

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -264,10 +264,14 @@ async def to_code(config):
 #    cg.add_library(
 #            name = "TFLite-Micro",
 #            repository="https://github.com/h3ndrik/tflite-micro-arduino-library.git",
-#            version="dd363b81abcc45d1d2447063972165ccc3dcc258"
+#            version="a30071d33b12cd29978febfbd7f1f90b1228a6c2"
 #        )
     cg.add_library("nickjgniklu/ESP_TF", "1.0.0")
-
+    cg.add_library(
+            name = "ESP_TF",
+            repository="https://github.com/h3ndrik/ESP_TF.git",
+            version="f51379aeba0207a2fdb8beb7b1a63727b38ae167"
+        )
 
 
     cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -270,7 +270,7 @@ async def to_code(config):
     cg.add_library(
             name = "ESP_TF",
             repository="https://github.com/h3ndrik/ESP_TF.git",
-            version="5a72c6bdddc04b637c254daf08a8964dc7334f5f"
+            version="193a61c31674db448be4224f82a802345d6170f9"
         )
 
 

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -266,11 +266,11 @@ async def to_code(config):
 #            repository="https://github.com/h3ndrik/tflite-micro-arduino-library.git",
 #            version="a30071d33b12cd29978febfbd7f1f90b1228a6c2"
 #        )
-    cg.add_library("nickjgniklu/ESP_TF", "1.0.0")
+    #cg.add_library("nickjgniklu/ESP_TF", "1.0.0")
     cg.add_library(
             name = "ESP_TF",
             repository="https://github.com/h3ndrik/ESP_TF.git",
-            version="193a61c31674db448be4224f82a802345d6170f9"
+            version="a41894f4b5a2c2d3e2268d875437592294594390"
         )
 
 

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_ON_CLIENT_CONNECTED,
     CONF_ON_CLIENT_DISCONNECTED,
 )
+from esphome.core import CORE
 from esphome import automation
 from esphome.automation import register_action, register_condition
 from esphome.components import microphone, speaker, media_player, esp32
@@ -261,18 +262,31 @@ async def to_code(config):
         )
 
     cg.add_define("USE_VOICE_ASSISTANT")
-#    cg.add_library(
-#            name = "TFLite-Micro",
-#            repository="https://github.com/h3ndrik/tflite-micro-arduino-library.git",
-#            version="a30071d33b12cd29978febfbd7f1f90b1228a6c2"
-#        )
-    #cg.add_library("nickjgniklu/ESP_TF", "1.0.0")
-    cg.add_library(
-            name = "ESP_TF",
-            repository="https://github.com/h3ndrik/ESP_TF.git",
-            version="a41894f4b5a2c2d3e2268d875437592294594390"
+    if CORE.using_esp_idf:
+        esp32.add_idf_component(
+            name="esp-tflite-micro",
+            repo="https://github.com/espressif/esp-tflite-micro",
+            # path="components",
+            # components=["esp-radar"],
         )
-
+        # esp32.add_idf_component(
+        #     name="esp-nn",
+        #     repo="https://github.com/espressif/esp-nn",
+        #     # path="components",
+        #     # components=["esp-radar"],
+        # )
+    if CORE.using_arduino:
+#        cg.add_library(
+#                name = "TFLite-Micro",
+#                repository="https://github.com/h3ndrik/tflite-micro-arduino-library.git",
+#                version="a30071d33b12cd29978febfbd7f1f90b1228a6c2"
+#            )
+        #cg.add_library("nickjgniklu/ESP_TF", "1.0.0")
+        cg.add_library(
+                name = "ESP_TF",
+                repository="https://github.com/h3ndrik/ESP_TF.git",
+                version="a41894f4b5a2c2d3e2268d875437592294594390"
+            )
 
     cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")
     cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -270,13 +270,13 @@ async def to_code(config):
     cg.add_library(
             name = "ESP_TF",
             repository="https://github.com/h3ndrik/ESP_TF.git",
-            version="f498f834b8728fe2522b62b80a2364ce2a646d61"
+            version="5a72c6bdddc04b637c254daf08a8964dc7334f5f"
         )
 
 
     cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")
     cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")
-    #cg.add_build_flag("-DESP_NN")
+    cg.add_build_flag("-DESP_NN")
     cg.add_build_flag("-DCONFIG_IDF_TARGET_ESP32")
     # CONFIG_IDF_TARGET_ESP32S3
 

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -84,9 +84,7 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_USE_WAKE_WORD, default=False): cv.boolean,
             cv.Optional(CONF_USE_LOCAL_WAKE_WORD, default=False): cv.boolean,
-            cv.Optional(CONF_VAD_THRESHOLD): cv.All(
-                cv.requires_component("esp_adf"), cv.only_with_esp_idf, cv.uint8_t
-            ),
+            cv.Optional(CONF_VAD_THRESHOLD): cv.All(cv.uint8_t),
             cv.Optional(CONF_NOISE_SUPPRESSION_LEVEL, default=0): cv.int_range(0, 4),
             cv.Optional(CONF_AUTO_GAIN, default="0dBFS"): cv.All(
                 cv.float_with_unit("decibel full scale", "(dBFS|dbfs|DBFS)"),

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -261,11 +261,14 @@ async def to_code(config):
         )
 
     cg.add_define("USE_VOICE_ASSISTANT")
-    cg.add_library(
-            name = "TFLite-Micro",
-            repository="https://github.com/h3ndrik/tflite-micro-arduino-library.git",
-            version="dd363b81abcc45d1d2447063972165ccc3dcc258"
-        )
+#    cg.add_library(
+#            name = "TFLite-Micro",
+#            repository="https://github.com/h3ndrik/tflite-micro-arduino-library.git",
+#            version="dd363b81abcc45d1d2447063972165ccc3dcc258"
+#        )
+    cg.add_library("nickjgniklu/ESP_TF", "1.0.0")
+
+
 
     cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")
     cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -270,7 +270,7 @@ async def to_code(config):
     cg.add_library(
             name = "ESP_TF",
             repository="https://github.com/h3ndrik/ESP_TF.git",
-            version="f51379aeba0207a2fdb8beb7b1a63727b38ae167"
+            version="f498f834b8728fe2522b62b80a2364ce2a646d61"
         )
 
 

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -276,8 +276,9 @@ async def to_code(config):
 
     cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")
     cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")
-    cg.add_build_flag("-DESP_NN")
+    #cg.add_build_flag("-DESP_NN")
     cg.add_build_flag("-DCONFIG_IDF_TARGET_ESP32")
+    # CONFIG_IDF_TARGET_ESP32S3
 
 
 VOICE_ASSISTANT_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(VoiceAssistant)})

--- a/esphome/components/voice_assistant/on_device_wake_word.cpp
+++ b/esphome/components/voice_assistant/on_device_wake_word.cpp
@@ -194,7 +194,7 @@ bool OnDeviceWakeWord::detect_wakeword(StreamBufferHandle_t &ring_buffer) {
 }
 
 bool OnDeviceWakeWord::slice_available_(StreamBufferHandle_t &ring_buffer) {
-  uint8_t slices_to_process = rb_bytes_filled(ring_buffer) / (NEW_SAMPLES_TO_GET * sizeof(int16_t));
+  uint8_t slices_to_process = xStreamBufferBytesAvailable(ring_buffer) / (NEW_SAMPLES_TO_GET * sizeof(int16_t));
 
   if (xStreamBufferBytesAvailable(ring_buffer) > NEW_SAMPLES_TO_GET*sizeof(int16_t)) {
     return true;

--- a/esphome/components/voice_assistant/on_device_wake_word.h
+++ b/esphome/components/voice_assistant/on_device_wake_word.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ringbuf.h>
+#include <freertos/stream_buffer.h>
 
 #include "tensorflow/lite/micro/system_setup.h"
 #include "tensorflow/lite/schema/schema_generated.h"
@@ -53,7 +53,7 @@ class OnDeviceWakeWord {
    * @param ring_Buffer Ring buffer containing raw audio samples
    * @return True if the wake word is detected, false otherwise
    */
-  bool detect_wakeword(ringbuf_handle_t &ring_buffer);
+  bool detect_wakeword(StreamBufferHandle_t &ring_buffer);
 
  protected:
   const tflite::Model *preprocessor_model_{nullptr};
@@ -80,14 +80,14 @@ class OnDeviceWakeWord {
   int16_t *preprocessor_stride_buffer_;
 
   /// @brief Returns true if there are enough audio samples in the buffer to generate another slice of features
-  bool slice_available_(ringbuf_handle_t &ring_buffer);
+  bool slice_available_(StreamBufferHandle_t &ring_buffer);
 
   /** Shifts previous feature slices over by one and generates a new slice of features
    *
    * @param ring_buffer ring buffer containing raw audio samples
    * @return True if a new slice of features was generated, false otherwise
    */
-  bool update_features_(ringbuf_handle_t &ring_buffer);
+  bool update_features_(StreamBufferHandle_t &ring_buffer);
 
   /** Generates features from audio samples
    *
@@ -113,7 +113,7 @@ class OnDeviceWakeWord {
    * @param audio_samples Pointer to an array that will store the strided audio samples
    * @return True if successful, false otherwise
    */
-  bool stride_audio_samples_(int16_t **audio_samples, ringbuf_handle_t &ring_buffer);
+  bool stride_audio_samples_(int16_t **audio_samples, StreamBufferHandle_t &ring_buffer);
 
   /// @brief Returns true if successfully registered the preprocessor's TensorFlow operations
   bool register_preprocessor_ops_(tflite::MicroMutableOpResolver<18> &op_resolver);

--- a/esphome/components/voice_assistant/on_device_wake_word.h
+++ b/esphome/components/voice_assistant/on_device_wake_word.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <freertos/FreeRTOS.h>
 #include <freertos/stream_buffer.h>
 
 #include "tensorflow/lite/micro/system_setup.h"

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -23,6 +23,7 @@ static const size_t BUFFER_SIZE = 1000 * SAMPLE_RATE_HZ / 1000;      // 1s
 static const size_t SEND_BUFFER_SIZE = INPUT_BUFFER_SIZE * sizeof(int16_t);
 static const size_t RECEIVE_SIZE = 1024;
 static const size_t SPEAKER_BUFFER_SIZE = 16 * RECEIVE_SIZE;
+static const float SNR_TRESHOLD_DB = 10.0;
 
 float VoiceAssistant::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
 
@@ -86,7 +87,9 @@ void VoiceAssistant::setup() {
     return;
   }
 
+#ifdef USE_ESP_ADF
   this->vad_instance_ = vad_create(VAD_MODE_4);
+#endif
 
   this->stream_buffer_ = xStreamBufferCreate(BUFFER_SIZE * sizeof(int16_t), 0);
   if (this->stream_buffer_ == nullptr) {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -126,8 +126,13 @@ int VoiceAssistant::read_microphone_() {
     size_t available = xStreamBufferSpacesAvailable(this->stream_buffer_);
     if (available < bytes_read) {
       xStreamBufferReceive(this->stream_buffer_, (void *) this->send_buffer_, bytes_read - available, 0);
+      ESP_LOGD(TAG, "ring buffer debug %d", bytes_read - available);
     }
-    xStreamBufferSend(this->stream_buffer_, (void *) this->input_buffer_, bytes_read, 0);
+    size_t xBytesSent = xStreamBufferSend(this->stream_buffer_, (void *) this->input_buffer_, bytes_read, 0);
+    if(xBytesSent != bytes_read) {
+      ESP_LOGD(TAG, "ring buffer overflow");
+    }
+
   } else {
     ESP_LOGD(TAG, "microphone not running");
   }

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -179,6 +179,8 @@ class VoiceAssistant : public Component {
 
   HighFrequencyLoopRequester high_freq_;
 
+  StreamBufferHandle_t stream_buffer_;
+
   uint8_t vad_threshold_{5};
   uint8_t vad_counter_{0};
 

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -19,9 +19,9 @@
 #endif
 #include "esphome/components/socket/socket.h"
 
+#include <freertos/stream_buffer.h>
 #ifdef USE_ESP_ADF
 #include <esp_vad.h>
-#include <ringbuf.h>
 #endif
 
 #include "on_device_wake_word.h"
@@ -95,9 +95,7 @@ class VoiceAssistant : public Component {
 
   void set_use_wake_word(bool use_wake_word) { this->use_wake_word_ = use_wake_word; }
   void set_use_local_wake_word(bool use_local_wake_word) { this->use_local_wake_word_ = use_local_wake_word; }
-#ifdef USE_ESP_ADF
   void set_vad_threshold(uint8_t vad_threshold) { this->vad_threshold_ = vad_threshold; }
-#endif
 
   void set_noise_suppression_level(uint8_t noise_suppression_level) {
     this->noise_suppression_level_ = noise_suppression_level;
@@ -180,11 +178,13 @@ class VoiceAssistant : public Component {
 
   HighFrequencyLoopRequester high_freq_;
 
-#ifdef USE_ESP_ADF
-  vad_handle_t vad_instance_;
-  ringbuf_handle_t ring_buffer_;
   uint8_t vad_threshold_{5};
   uint8_t vad_counter_{0};
+
+#ifdef USE_ESP_ADF
+  vad_handle_t vad_instance_;
+#else
+  uint16_t noise_floor_{0};
 #endif
 
   bool use_wake_word_;

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -19,6 +19,7 @@
 #endif
 #include "esphome/components/socket/socket.h"
 
+#include <freertos/FreeRTOS.h>
 #include <freertos/stream_buffer.h>
 #ifdef USE_ESP_ADF
 #include <esp_vad.h>


### PR DESCRIPTION
I did a quick proof of concept to get the local wake word detection running on my ESP32 (without the S3) board. I also use the media_player coponent so I had to rewrite it to use the Arduino framework instead of the IDF.

I started removing the dependencies on the ADF, analogous to my PR in esphome: https://github.com/esphome/esphome/pull/5613

(That PR is also still a draft, since doing Voice Activity Detection is hard without proper signal processing. Just relying on the loudness doesn't work reliably and I've been waiting on something like this to get to something that is actually working.)

Unfortunately espressif's fork of tensorflow micro is only available as an IDF component. I found [an (outdated) project](https://github.com/Nickjgniklu/ESP_TF) that adapts that to an Arduino library. I made a fork and updated it: https://github.com/h3ndrik/ESP_TF

This isn't ready to merge yet. I'd like to receive some comments on the approach before cleaning it up and adding a few conditions so it either pulls in the IDF component or the Arduino library.

Btw: How do you measure performance? The debug component shows a loop time of 50-60ms on a plain ESP32.

