### PR TITLE
Fix http/shortname model loading

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -291,6 +291,11 @@ async def to_code(config):
             with open(model_config[CONF_PATH], "rb") as f:
                 data = f.read()
 
+        elif model_config[CONF_TYPE] == TYPE_HTTP:
+            path = _compute_local_file_path(model_config)
+            with open(path, "rb") as f:
+                data = f.read()
+
         rhs = [HexInt(x) for x in data]
         prog_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)
         cg.add(var.set_model_start(prog_arr))


### PR DESCRIPTION
Models were not being loaded into the firmware, only downloaded locally. Not sure how I missed this part.